### PR TITLE
Add ARM64 none-haiku cross target

### DIFF
--- a/build/jam/ArchitectureRules
+++ b/build/jam/ArchitectureRules
@@ -40,7 +40,7 @@ rule ArchitectureSetup architecture
 	switch $(cpu) {
 		case ppc : archFlags += -mcpu=440fp ;
 		case arm : archFlags += -march=armv7-a -mfloat-abi=hard ;
-		case arm64 : archFlags += -march=armv8.2-a+fp16 ;
+               case arm64 : archFlags += -march=armv8.6-a+crypto+lse2 ;
 		case x86 : archFlags += -march=pentium ;
 		case riscv64 : archFlags += -march=rv64gc ;
 	}
@@ -312,9 +312,9 @@ rule KernelArchitectureSetup architecture
                        }
 
                case arm64 :
-                       # arm64 uses aarch64 GNU triplet
-                       HAIKU_GNU_MACHINE = aarch64 ;
-                       HAIKU_GNU_MACHINE_TRIPLET = aarch64-unknown-haiku ;
+               # arm64 uses aarch64 GNU triplet
+               HAIKU_GNU_MACHINE = aarch64 ;
+               HAIKU_GNU_MACHINE_TRIPLET = $(HAIKU_GNU_MACHINE_TRIPLET_arm64) ;
 
                        HAIKU_KERNEL_PLATFORM ?= efi ;
                        HAIKU_BOOT_TARGETS += efi ;

--- a/build/jam/BuildSetup
+++ b/build/jam/BuildSetup
@@ -14,6 +14,10 @@
 # attached.
 HAIKU_VERSION = r1~beta5 ;
 
+# Default GNU triplet for ARM64 cross builds. This can be overridden in
+# UserBuildConfig when using a custom toolchain.
+HAIKU_GNU_MACHINE_TRIPLET_arm64 ?= aarch64-none-haiku ;
+
 
 #pragma mark - container settings
 

--- a/build/jam/UserBuildConfig.ReadMe
+++ b/build/jam/UserBuildConfig.ReadMe
@@ -54,6 +54,12 @@ DEBUG on <src!bin!gdb!gdb!>haiku-nat.o = 1 ;
 # feature.
 HAIKU_BUILD_FEATURE_SSL = 1 ;
 
+# ARM64 cross compilation example: use an alternate GNU triplet and
+# enable ARMv8.6-A CPU features with crypto and LSE2 extensions.
+HAIKU_GNU_MACHINE_TRIPLET_arm64 = aarch64-none-haiku ;
+AppendToConfigVar HAIKU_CCFLAGS_arm64 : -march=armv8.6-a+crypto+lse2 ;
+AppendToConfigVar HAIKU_C++FLAGS_arm64 : -march=armv8.6-a+crypto+lse2 ;
+
 
 # Haiku Image Related Modifications
 


### PR DESCRIPTION
## Summary
- add default GNU triplet for ARM64 cross builds
- enable ARMv8.6-A crypto and LSE2 flags
- expose ARM64 triplet and flags in UserBuildConfig

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0dcf303483328d09418a8d9d73db